### PR TITLE
Adjust regex to handle more whitespace permutations

### DIFF
--- a/oscopilot/modules/base_module.py
+++ b/oscopilot/modules/base_module.py
@@ -63,7 +63,7 @@ class BaseModule:
             str: An error message indicating a parsing error or that no JSON data was found.
         """
         # Improved regular expression to find JSON data within a string
-        json_regex = r'```json\s*\n\{[\s\S]*?\n\}\s*```'
+        json_regex = r'```json\n\s*\{\n\s*[\s\S\n]*\}\n\s*```'
         
         # Search for JSON data in the text
         matches = re.findall(json_regex, text)


### PR DESCRIPTION
After hitting frequent errors due to ChatGPT variability in whitespace formatting, added this regex which addressed the problem