### PR TITLE
Fixed "list index out of range" error in repair_tool by adding conditional check for BASH tool type

### DIFF
--- a/oscopilot/modules/executor/friday_executor.py
+++ b/oscopilot/modules/executor/friday_executor.py
@@ -226,8 +226,13 @@ class FridayExecutor(BaseModule):
                 pre_tasks_info = pre_tasks_info
             )
         amend_msg = send_chat_prompts(sys_prompt, user_prompt, self.llm)
-        new_code = self.extract_python_code(amend_msg)
-        invoke = self.extract_information(amend_msg, begin_str='<invoke>', end_str='</invoke>')[0]
+        
+        new_code = self.extract_code(amend_msg, tool_type)
+        if tool_type == 'Python':
+            invoke = self.extract_information(amend_msg, begin_str='<invoke>', end_str='</invoke>')[0]
+        else:
+            invoke = ''
+            
         return new_code, invoke
 
     @api_exception_mechanism(max_retries=3)


### PR DESCRIPTION
**Bug:**
When OS-Copilot attempts to repair a BASH tool upon failure, it throws "list index out of range" error. I added comprehensive logs to generate the following traceback:
```
[SDnQZBs09BS2hhOS] 2024-12-17 20:08:35,919 - ERROR - Error on attempt 3 in repair_tool: list index out of range
Traceback (most recent call last):
  File "/home/ubuntu/research/OS-Copilot/oscopilot/utils/utils.py", line 536, in wrapper
    return func(*args, **kwargs)
  File "/home/ubuntu/research/OS-Copilot/oscopilot/modules/executor/friday_executor.py", line 232, in repair_tool
    invoke = self.extract_information(amend_msg, begin_str='<invoke>', end_str='</invoke>')[0]
IndexError: list index out of range

[SDnQZBs09BS2hhOS] 2024-12-17 20:08:35,920 - ERROR - Max retries reached in repair_tool, operation failed.
```

**Source:**
The source of bug resides in the file `OS-Copilot/oscopilot/modules/executor/friday_executor.py` in function `repair_tool` > line 230 `invoke = self.extract_information(amend_msg, begin_str='<invoke>', end_str='</invoke>')[0]`.

**Description:**
The input to it is the repaired `bash` code from generated from `send_chat_prompts`. Since the `extract_information` which extracts content enclosed within flags and works for Python code as BASH content don't include it, as per the prompt says, returns None. Thus, [0] fails! Another thing, `extract_python_code` works same as `extract_code`.

**Solution:**
Added additional check for `tool_type`. However, this issue is already handled by the another member function `execute_tool`. 

Thanks.
